### PR TITLE
Use `...' quote for avoiding byte-compile warnings

### DIFF
--- a/battery-notifier.el
+++ b/battery-notifier.el
@@ -86,7 +86,7 @@
   :group 'battery-notifier)
 
 (defcustom battery-notifier-capacity-critical-threshold 5
-  "The threshold below which the 'battery-notifier-capacity-critical-hook' will run."
+  "The threshold below which the `battery-notifier-capacity-critical-hook' will run."
   :type '(choice
           (integer :tag "Specify critical capacity threshold")
           (const :tag "Do nothing" nil))
@@ -135,7 +135,7 @@
         (run-hooks 'battery-notifier-capacity-critical-hook)))))
 
 (defun battery-notifier-watch ()
-  "Start the 'battery-notifier-timer'."
+  "Start the `battery-notifier-timer'."
   (setq battery-notifier-timer
         (run-with-timer 2 battery-notifier-timer-interval 'battery-notifier-check)))
 
@@ -145,7 +145,7 @@
 
 ;;;###autoload
 (define-minor-mode battery-notifier-mode
-  "Toggle use of 'battery-notifier-mode'.
+  "Toggle use of `battery-notifier-mode'.
 This global minor mode sends notifications when battery capacity is low
 and runs action hooks when battery capacity is critically low."
   :lighter " enabled"


### PR DESCRIPTION
Newer Emacs(development) warns as below.

```
battery-notifier.el:88:2: Warning: custom-declare-variable
    `battery-notifier-capacity-critical-threshold' docstring has wrong usage
    of unescaped single quotes (use \= or different quoting)

In battery-notifier-watch:
battery-notifier.el:137:2: Warning: docstring has wrong usage of unescaped
    single quotes (use \= or different quoting)

In battery-notifier-mode:
battery-notifier.el:147:2: Warning: docstring has wrong usage of unescaped
    single quotes (use \= or different quoting)
```

And `..' quote for variables or functions works like links as below.

#### Original

![before](https://user-images.githubusercontent.com/554281/177186937-8fd9ab23-8dbc-4021-8214-a08e5c3e370c.png)

#### This version

![after](https://user-images.githubusercontent.com/554281/177186904-fe5755be-a7de-47f7-b515-1bb8ead2be72.png)

